### PR TITLE
Update schema_tracking_log.json to include has_saved_answers

### DIFF
--- a/edx2bigquery/schemas/schema_tracking_log.json
+++ b/edx2bigquery/schemas/schema_tracking_log.json
@@ -193,6 +193,10 @@
                             "name": "done"
                         }, 
                         {
+                            "type": "BOOLEAN", 
+                            "name": "has_saved_answers"
+                        }, 
+                        {
                             "type": "STRING", 
                             "name": "correct_map"
                         }, 


### PR DESCRIPTION
Split throws exception when encountering new schema field 

Exception: [check_schema] Oops! field has_saved_answers is not in the schema, linecnt=0, path=/event_struct/state